### PR TITLE
Allow clientside 'emit' calls that have a callback but no data.

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -127,6 +127,8 @@ express.application.listen = ->
 initRoutes = (socket, io) ->
     setRoute = (key, callback) ->
         socket.on key, (data, respond) ->
+            if typeof data is 'function'
+                respond = data
             request =
                 data: data
                 session: socket.handshake.session


### PR DESCRIPTION
Pure socketio allows this:

socket.emit 'name', (junk) ->
  ...

but express.io will break unless you do

socket.emit 'name', {}, (junk) ->
  ...
