### PR TITLE
report error when sessions are configured but no cookie is presented

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -69,6 +69,7 @@ express.application.io = (options) ->
                 return cookieParser request, null, (error) ->
                     data.cookies = request.cookies
                     rawCookie = data.cookies[sessionConfig.key]
+                    return next "No cookie present", false unless rawCookie?
                     sessionId = connect.utils.parseSignedCookie rawCookie, sessionConfig.secret
                     data.sessionID = sessionId
                     sessionConfig.store.get sessionId, (error, session) ->


### PR DESCRIPTION
This is a small change that prevents the server from throwing a stack trace as mentioned in issue #11.
