### PR TITLE
Fix a typo on the Rooms readme

### DIFF
--- a/examples/rooms/README.md
+++ b/examples/rooms/README.md
@@ -1,4 +1,3 @@
-
 ## Rooms
 
 __This is a copy-paste example.__ 
@@ -8,7 +7,7 @@ Sometimes you will want to group your io clients together into rooms.  With __ex
 * `req.io.join(room)` - The client for the request joins `room`.
 * `req.io.leave(room)` - The client for the request leaves `room`.
 * `req.io.room(room).broadcast(event, data)` - Broadcast to all client in the room except for the current one.
-* `app.io.room(room).brodcast(event, data)` - Broadcast to all clients in the room.
+* `app.io.room(room).broadcast(event, data)` - Broadcast to all clients in the room.
 
 For this example, open two browser windows on `localhost:7076`.  You will be prompted to give a room name.  Enter the same room name for each browser, then check back with the first window to see the result.
 


### PR DESCRIPTION
Looked at the code, assuming this is a typo, and the important part between the two room examples is the app vs. request difference, not the method name.
