### PR TITLE
Fix in <key,value> usage in middleware variable parsing

### DIFF
--- a/lib/middleware.coffee
+++ b/lib/middleware.coffee
@@ -59,8 +59,8 @@ exports.routeForward = (options) ->
                 if match?
                     meta.variables ?= []
                     request.params ?= {}
-                    for variable, index of meta.variables
-                        request.params[variable] = match[index + 2]
+                    for index, variable of meta.variables
+                        request.params[variable] = match[2 + parseInt(index)]
                     return request.io.route("#{match[1]}:#{route}")
         next()
         


### PR DESCRIPTION
Previous case was reading as [value, key].
Fix for index being treated as string and causing extracted 'id' variable to be undefined
