### PR TITLE
Updated readme's with some additional methods that didn't seem to be covered.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Or put your routes into a separate file for that nice and tidy look
 ```js
 //in app.js pass in "app" so you can use it anywhere.
 var realtime = require('./realtime')(app)
+app.io.route('ready', realtime.ready )
 
 //in realtime.js
 module.exports = function(app){

--- a/README.md
+++ b/README.md
@@ -72,7 +72,24 @@ app.io.route('my-realtime-route', function(req) {
     // respond to the event
 });
 ```
+Or put your routes into a separate file for that nice and tidy look
+```js
+//in app.js pass in "app" so you can use it anywhere.
+var realtime = require('./realtime')(app)
 
+//in realtime.js
+module.exports = function(app){
+    return {
+        ready: function(req) {
+            req.io.emit('lessClutter', {separate: "those concerns"})
+        },
+        
+        set: function(req){
+            app.io.broadcast('talkToServer', {to: "Everyone."})
+        }
+    }
+};
+```
 ## Automatic Session Support
 
 Sessions work automatically, just set them up like normal using express.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ module.exports = function(app){
         ready: function(req) {
             req.io.emit('lessClutter', {separate: "those concerns"})
         },
-        
         set: function(req){
             app.io.broadcast('talkToServer', {to: "Everyone."})
         }

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,4 +1,3 @@
-
 # API Reference
 
 This gives details on the new top level objects for __express.io__.   
@@ -38,6 +37,14 @@ app.io.room('hipster').broadcast('meh', {this: 'goes to all hipsters'})
 app.io.route('special', function(req) {
     // do something with req
 })
+```
+
+You can also access all of the socket.io sockets, an example to disconnect all clients before shutdown
+```js
+app.io.sockets.clients().forEach(function (socket) {
+        socket.disconnect();
+        logger.info(socket.username + ' disconnected for shutdown');
+});
 ```
 
 You can also use the `AppIO` object to configure your io server.  For available options, check [here](https://github.com/LearnBoost/Socket.IO/wiki/Configuring-Socket.IO).


### PR DESCRIPTION
Including the issue I opened earlier concerning external routing, as well as accessing the app.io.sockets.clients() objects, ie. to send disconnects to all of them on shutdown.
