### PR TITLE
Route Forwarding: receive multiple arguments `res.io.respond(a,b,c,...)`

### DIFF
--- a/examples/route-forwarding/README.md
+++ b/examples/route-forwarding/README.md
@@ -34,7 +34,7 @@ app.io.route('hello-again', function(req) {
 app.listen(7076)
 ```
 
-__Note__: When you forward http requests to io routes, `req.io.respond(data)` will call `res.json(data)` on the actual http request.  This  makes sense because http routes require a response, and the `respond` method is supposed to be a response for the given request.
+__Note__: When you forward http requests to io routes, `req.io.respond(err, data)` will call `res.json([err, data])` on the actual http request.  This  makes sense because http routes require a response, and the `respond` method is supposed to be a response for the given request.
 
 Also, depending on the sophistication needed between a socket request and a web request, you might consider writing your own custom middleware layer and overriding `req.io.route` for your web requests.
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -109,7 +109,7 @@ express.application.io = (options) ->
                         broadcast: @io.broadcast
                         respond: =>
                             args = Array.prototype.slice.call arguments, 0
-                            response.json.apply response, args
+                            response.json.call response, args
                         route: (route) =>
                             @io.route route, ioRequest, trigger: true
                         data: request.body


### PR DESCRIPTION
I love the idea of Route Forwarding but somehow encounter a problem. I prefer pass result or error to browser with node style `[err, result, ...]` which is really common convention

``` js
    try {
        var data = doSomething();
        res.io.respond(null, data);
    } catch(err) {
        res.io.respond(err);
    }
```

but it doesnt work with Route-Forwarding because express's `res.json` expect additional param as status code, so `res.io.respond(null, data)` => `res.json(null, data)` just crash express.

writing sth. like `res.io.respond(500, err)` works with current express.io but really sounds strange, so I send this PR to change this behavior. it does break backward compatibility but I believe it worth that
