### PR TITLE
Fix for exception error when null options are passed

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -34,7 +34,7 @@ express.application.https = (options) ->
     return this
 
 express.application.io = (options) ->
-    options ?= ''
+    options ?= new Object
     defaultOptions = log:false
     _.extend options, defaultOptions
     @io = io.listen @server, options

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -16,12 +16,19 @@ express.io.routeForward = middleware.routeForward
 session = express.session
 delete express.session
 sessionConfig = new Object
+
 express.session = (options) ->
-    options ?= ''
-    options.key ?= 'connect.sid'
-    options.store ?= new session.MemoryStore
-    options.cookie ?= new Object
-    return session options
+  if options is null
+    options =
+      key: "connect.sid"
+      store: session.MemoryStore
+      cookie:
+        path: "/"
+        httpOnly: true
+        secure: false
+        maxAge: {}
+  session options
+  
 for key, value of session
     express.session[key] = value
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -17,11 +17,10 @@ session = express.session
 delete express.session
 sessionConfig = new Object
 express.session = (options) ->
-    options ?= new Object
+    options ?= ''
     options.key ?= 'connect.sid'
     options.store ?= new session.MemoryStore
     options.cookie ?= new Object
-    sessionConfig = options
     return session options
 for key, value of session
     express.session[key] = value
@@ -35,7 +34,7 @@ express.application.https = (options) ->
     return this
 
 express.application.io = (options) ->
-    options ?= new Object
+    options ?= ''
     defaultOptions = log:false
     _.extend options, defaultOptions
     @io = io.listen @server, options

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": ["realtime", "web", "framework", "express.io", "express", "socket.io", "badass"],
     "homepage": "http://express-io.org",
     "author": "Brad Carleton <brad@techpines.com>",
-    "repository": "git://github.com/techpines/express.io",
+    "repository": "git://github.com/killerbobjr/express.io",
     "contributors": [{
         "name": "Brad Carleton",
         "email": "brad@techpines.com",
@@ -35,13 +35,13 @@
         "mocha": "*",
         "chai": "*",
         "socket.io-client": "*",
-        "jade": "*"
+        "jade": "*",
+	"shelljs-nodecli": "*"
     },
     "main": "switch.js",
     "scripts": {
         "test": "./node_modules/mocha/bin/mocha test/test.coffee",
         "compile": "./node_modules/coffee-script/bin/coffee -o compiled/ -c lib/",
-        "prepublish": "echo $(pwd) > /tmp/.pwd; ./node_modules/coffee-script/bin/coffee -o compiled/ -c lib/;",
-        "postpublish": "rm -rf $(cat /tmp/.pwd)/compiled"
+        "prepublish": "node ./scripts/prepublish.js"
     }
 }

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,4 @@
+var shell = require('shelljs-nodecli/node_modules/shelljs');
+var cli = require('shelljs-nodecli');
+shell.mkdir('-p', 'compiled');
+cli.exec('coffee', '-o compiled/', '-c lib');


### PR DESCRIPTION
Also updated package.json to be platform independent

If no options are passed into express.session(), a null object is created which causes express to throw an exception during the "typeof string" check.

I've initialized any null options object with a blank string so it will pass the string check (my previous fix didn't allow sessionOptions to be cleared in a new session). I've also done the same as a precaution for the express.application.io options as well.

Additionally, I've created a prepublish script for coffee compilation that is platform independent (based on shelljs and shelljs-nodecli).
